### PR TITLE
Add Python 2.6 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ branches:
     - master
 
 env:
+  - TOXENV=py26
   - TOXENV=py27
   - TOXENV=py32
   - TOXENV=py33

--- a/CHANGES
+++ b/CHANGES
@@ -8,6 +8,7 @@
   (release date to be announced)
 
   - Add French localization.
+  - Add Python 2.6 support.
 
 
 ~ Version 0.3

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -23,6 +23,9 @@ installation::
 
     $ [sudo] pip install em
 
+.. note:: For some reason the Python 2.6 support has been added, but
+    ``argparse`` is required and will be installed from PyPI.
+
 
 Quickstart
 ----------

--- a/em/__init__.py
+++ b/em/__init__.py
@@ -21,7 +21,7 @@ import gettext
 import argparse
 
 
-__version__ = '0.4-dev'
+__version__ = '0.4.dev'
 
 
 #: True if Python 2.x interpreter was detected
@@ -118,7 +118,7 @@ def emphasize(stream, patterns):
         flags = re.UNICODE
         flags |= re.IGNORECASE if v['ignore_case'] else 0
         return re.compile('(%s)' % k, flags)
-    patterns = {re_compile(k, v): v for k, v in patterns.items()}
+    patterns = dict((re_compile(k, v), v) for k, v in patterns.items())
 
     # don't use `stream.read()` (or its iterative interface) here as it can
     # possibly block until the block of the requested size is read fully

--- a/em/tests/__init__.py
+++ b/em/tests/__init__.py
@@ -96,3 +96,10 @@ class EmTestCase(unittest.TestCase):
         # send data to stdin if needed
         standard_output, _ = p.communicate(input=standard_input)
         return standard_output.decode('utf-8')
+
+
+if 'assertIn' not in dir(EmTestCase):
+    EmTestCase.assertIn = lambda _, v, c: v in c
+
+if 'assertNotIn' not in dir(EmTestCase):
+    EmTestCase.assertNotIn = lambda _, v, c: v not in c

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,13 @@ import glob
 import subprocess
 
 from setuptools import setup, Command
-from em import __version__ as em_version
+
+
+install_requires = []
+try:
+    import argparse  # NOQA
+except ImportError:
+    install_requires.append('argparse')
 
 
 class LocaleUpdate(Command):
@@ -80,7 +86,7 @@ class LocaleCompile(Command):
 
 setup(
     name='em',
-    version=em_version,
+    version='0.4.dev',
     url='https://github.com/ikalnitsky/em',
     license='BSD',
     author='Igor Kalnitsky',
@@ -92,6 +98,7 @@ setup(
         'em',
         'em.tests',
     ],
+    install_requires=install_requires,
     test_suite='em.tests',
     entry_points={
         'console_scripts': ['em = em:main'],

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-  py27, py32, py33, py34, pypy, docs, flake8
+  py26, py27, py32, py33, py34, pypy, docs, flake8
 
 
 [testenv]


### PR DESCRIPTION
Unfortunately, I have a lot of CentOS installations on my work
with Python 2.6. So I had to make possible run it over Python 2.6.
