### PR TITLE
Set default highlighting color

### DIFF
--- a/README
+++ b/README
@@ -36,7 +36,7 @@
 
   The most practical usecase for me:
 
-      $ tail -f /path/to/log | em "ERROR" red | em "WARNING" yellow
+      $ tail -f /path/to/log | em "ERROR" -f red | em "WARNING" -f yellow
 
   See the documentations for details: http://em.readthedocs.org/.
 

--- a/em/__init__.py
+++ b/em/__init__.py
@@ -150,9 +150,9 @@ def get_arguments():
         epilog=_(
             'With no FILE, or when FILE is -, read standard input.'
             '  '
-            'The FORMAT option must be one of: BOLD, UNDERLINE, [ON]GREY, '
+            'The FORMAT option may be one of: BOLD, UNDERLINE, [ON]GREY, '
             '[ON]RED, [ON]GREEN, [ON]YELLOW, [ON]BLUE, [ON]MAGENTA, [ON]CYAN '
-            'or [ON]WHITE.'),
+            'or [ON]WHITE. Default is RED.'),
 
         # disable it and add help option manually
         # we need this trick to localize help message
@@ -163,7 +163,7 @@ def get_arguments():
     arg.help = _('a pattern to highlight')
     arg.type = _str_to_unicode
 
-    arg = parser.add_argument('format', metavar='FORMAT')
+    arg = parser.add_argument('-f', '--format', metavar='FORMAT', default='RED')
     arg.help = _('a color to highlight matched expressions')
 
     arg = parser.add_argument('files', metavar='FILE', nargs='*', default=['-'])

--- a/em/tests/basic.py
+++ b/em/tests/basic.py
@@ -29,30 +29,30 @@ class BasicFunctionalityTestCase(EmTestCase):
         ]
 
     def test_run_with_default(self):
-        output = self.execute(['em', 'rival', 'RED'], self.text)
+        output = self.execute(['em', 'rival', '-f', 'RED'], self.text)
         self.assertColoredPhraseIn('rival', 'red', output)
 
     def test_run_with_no_result(self):
-        output = self.execute(['em', 'Monte-Cristo', 'RED'], self.text)
+        output = self.execute(['em', 'Monte-Cristo', '-f', 'RED'], self.text)
         self.assertColoredPhraseNotIn('Monte-Cristo', 'red', output)
 
     def test_run_with_a_few_words(self):
-        output = self.execute(['em', 'no man', 'green'], self.text)
+        output = self.execute(['em', 'no man', '-f', 'green'], self.text)
         self.assertColoredPhraseIn('no man', 'green', output)
 
     def test_run_with_line_mode(self):
-        output = self.execute(['em', 'future', 'blue', '-l'], self.text)
+        output = self.execute(['em', 'future', '-f', 'blue', '-l'], self.text)
         self.assertColoredPhraseIn(self.text[-1], 'blue', output)
 
     def test_run_with_ignore_case(self):
-        output = self.execute(['em', 'No MaN', 'bold'], self.text)
+        output = self.execute(['em', 'No MaN', '-f', 'bold'], self.text)
         self.assertColoredPhraseNotIn('no man', 'bold', output)
 
-        output = self.execute(['em', 'No MaN', 'cyan', '-i'], self.text)
+        output = self.execute(['em', 'No MaN', '-f', 'cyan', '-i'], self.text)
         self.assertColoredPhraseIn('no man', 'cyan', output)
 
     def test_run_with_multiple_arguments(self):
-        output = self.execute(['em', 'BLOOD', 'red', '-i', '-l'], self.text)
+        output = self.execute(['em', 'BLOOD', '-f', 'red', '-i', '-l'], self.text)
         self.assertColoredPhraseIn(self.text[0], 'red', output)
 
     def test_formatting_feature(self):
@@ -82,5 +82,5 @@ class BasicFunctionalityTestCase(EmTestCase):
         for format_ in formats:
             # test both uppercased and lowercased variants
             for fmt in (format_.lower(), format_.upper()):
-                output = self.execute(['em', 'immortal', fmt], self.text)
+                output = self.execute(['em', 'immortal', '-f', fmt], self.text)
                 self.assertColoredPhraseIn('immortal', fmt, output)

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ Em is Cool
 
 .. code:: bash
 
-    $ tail -f /path/to/log | em "DEBUG|INFO" GREEN | em "WARN" yellow
+    $ tail -f /path/to/log | em "DEBUG|INFO" -f green | em "WARN"
 
 
 Links


### PR DESCRIPTION
This helps to avoid typing an extra word every time as most frequest usecase:
just highlight required pattern with something.
